### PR TITLE
反序列化错误

### DIFF
--- a/lib/multipart.js
+++ b/lib/multipart.js
@@ -50,7 +50,7 @@ proto.multipartUpload = function* multipartUpload(name, file, options) {
       name: name,
       etag: result.res.headers.etag
     };
-    if (options.headers && options.headers['x-oss-callback']) {
+    if (!(options.headers && options.headers['x-oss-callback'])) {
       ret.data = JSON.parse(result.data.toString());
     }
     return ret;


### PR DESCRIPTION
在putstream中已经对resutl.data进行反序列化，所以在54行对一个object类型进行tostring()操作，导致JSON.parse报错。